### PR TITLE
Fix video upload BigInt error

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
   "browserslist": {
     "production": [
       ">0.2%",
-      "not dead",
       "not op_mini all"
     ],
     "development": [


### PR DESCRIPTION
Previously we were targeting "not dead" browsers. This is not compatible with the external dfinity agent code which requires a ES2020 compilation so was causing type errors on the video upload.