### PR TITLE
Fix: Stops compiling BigInt exponentiation to Math.pow 

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,8 +68,10 @@
   },
   "browserslist": {
     "production": [
-      ">0.2%",
-      "not op_mini all"
+      "last 2 chrome version",
+      "last 2 firefox version",
+      "last 2 safari version",
+      "last 2 edge version"
     ],
     "development": [
       "last 1 chrome version",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "module": "esnext",
     "downlevelIteration": true,
     "strict": true,
-    "target": "es6",
+    "target": "es2018",
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
Sets more prescriptive rules about browser support to ensure browserlist doesn't include browsers which don't support `**`, as this project uses libraries which require it.