### PR TITLE
[CAN-117] [CAN-122] Respect abuse flaggers' privacy in FE-BE API.

### DIFF
--- a/backend/Param.mo
+++ b/backend/Param.mo
@@ -17,6 +17,11 @@ module {
   /// Users may not super like more than this many videos per "recent duration of time".
   public let maxRecentSuperLikes : Nat = 10;
 
+  /// Abuse flag limit.
+  ///
+  /// Users may not abuse-flag more than this many videos per "recent duration of time".
+  public let maxRecentAbuseFlags : Nat = 10;
+
   /// Super like viral threshold.
   ///
   /// When a video has this many super likes, the system "emits" a viralVideo signal.

--- a/backend/State.mo
+++ b/backend/State.mo
@@ -116,6 +116,7 @@ module {
     };
 
     public type Event = {
+      id : Nat; // unique ID, to avoid using time as one (not always unique)
       time : Int; // using mo:base/Time and Time.now() : Int
       kind : EventKind;
     };
@@ -134,6 +135,7 @@ module {
 
     /// event log.
     eventLog : Event.Log;
+    var eventCount : Nat;
 
     /// all profiles.
     profiles : Map<Types.UserId, Profile>;
@@ -228,8 +230,7 @@ module {
     let equal = (Text.equal, Text.equal);
     let hash = (Text.hash, Text.hash);
     func messageEqual(a: Types.Message, b: Types.Message) : Bool = a == b;
-    // not a very good hash, but we are not using the hash
-    func messageHash(m: Types.Message) : Hash.Hash = Int.hash(m.time);
+    func messageHash(m: Types.Message) : Hash.Hash = Int.hash(m.id); // id is unique, so hash is unique
     let uploaded_ = RelObj.RelObj<Types.UserId, Types.VideoId>(hash, equal);
     let st : State = {
       access = Access.Access({ admin = init.admin ; uploaded = uploaded_ });
@@ -245,6 +246,7 @@ module {
       superLikes = RelObj.RelObj(hash, equal);
       uploaded = uploaded_;
       eventLog = SeqObj.Seq<Event.Event>(Event.equal, null);
+      var eventCount = 0;
       abuseFlagVideos = RelObj.RelObj(hash, equal);
       abuseFlagUsers = RelObj.RelObj(hash, equal);
     };

--- a/backend/Types.mo
+++ b/backend/Types.mo
@@ -62,7 +62,7 @@ public type AllowanceBalance = {
   /// Non-zero balance of the given amount (the allowance unit varies by use).
   #nonZero : Nat;
   /// Zero now, and will be zero until the IC reaches the given time.
-  #zeroUtil : Timestamp;
+  #zeroUntil : Timestamp;
 };
 
 /// "Deeper" version of ProfileInfo.

--- a/backend/Types.mo
+++ b/backend/Types.mo
@@ -55,9 +55,12 @@ public type ProfileInfo = {
  likedVideos: [VideoId];
  hasPic: Bool;
  rewards: Nat;
- abuseFlags: Nat; // abuseFlags counts other users' flags on this profile, for possible blurring.
+ abuseFlagCount: Nat; // abuseFlags counts other users' flags on this profile, for possible blurring.
 };
 
+/// "Deeper" version of ProfileInfo.
+///
+/// Gives Video- and ProfileInfos instead of merely Ids in the results.
 public type ProfileInfoPlus = {
   userName: Text;
  following: [ProfileInfo];
@@ -66,7 +69,12 @@ public type ProfileInfoPlus = {
  likedVideos: [VideoInfo];
  hasPic: Bool;
  rewards: Nat;
- abuseFlags: Nat; // abuseFlags counts other users' flags on this profile, for possible blurring.
+ abuseFlagCount: Nat; // abuseFlags counts other users' flags on this profile, for possible blurring.
+ /// abuseFlagFlag is
+ /// ?true if we (the User requesting this profile) has flagged this profile for abuse.
+ /// ?false if not, and
+ /// null if no specific requesting user is defined by context.
+ abuseFlagFlag: ?Bool;
 };
 
 /// video information provided by front end to service, upon creation.
@@ -94,7 +102,12 @@ public type VideoInfo = {
  viewCount: Nat;
  name: Text;
  chunkCount: Nat;
- abuseFlagUsers: [UserId]; // A lit of users that have flagged this video for abuse
+ abuseFlagCount: Nat; // abuseFlags counts other users' flags on this profile, for possible blurring.
+ /// abuseFlagFlag is
+ /// ?true if we (the User requesting this profile) has flagged this profile for abuse.
+ /// ?false if not, and
+ /// null if no specific requesting user is defined by context.
+ abuseFlagFlag: ?Bool; // true if we (the User requesting this profile) has flagged this profile for abuse.
 };
 
 public type VideoResult = (VideoInfo, ?VideoPic);

--- a/backend/Types.mo
+++ b/backend/Types.mo
@@ -63,6 +63,8 @@ public type AllowanceBalance = {
   #nonZero : Nat;
   /// Zero now, and will be zero until the IC reaches the given time.
   #zeroUntil : Timestamp;
+  /// No allowance at all, ever.
+  #zeroForever
 };
 
 /// "Deeper" version of ProfileInfo.
@@ -132,6 +134,7 @@ public type VideoResults = [VideoResult];
 
 /// Notification messages
 public type Message = {
+  id: Nat;
     time: Timestamp;
     event: Event;
 };

--- a/backend/Types.mo
+++ b/backend/Types.mo
@@ -58,6 +58,13 @@ public type ProfileInfo = {
  abuseFlagCount: Nat; // abuseFlags counts other users' flags on this profile, for possible blurring.
 };
 
+public type AllowanceBalance = {
+  /// Non-zero balance of the given amount (the allowance unit varies by use).
+  #nonZero : Nat;
+  /// Zero now, and will be zero until the IC reaches the given time.
+  #zeroUtil : Timestamp;
+};
+
 /// "Deeper" version of ProfileInfo.
 ///
 /// Gives Video- and ProfileInfos instead of merely Ids in the results.
@@ -75,6 +82,16 @@ public type ProfileInfoPlus = {
  /// ?false if not, and
  /// null if no specific requesting user is defined by context.
  abuseFlagFlag: ?Bool;
+ /// null if not giving a self view of the profile, otherwise, gives UserAllowances for userName.
+ allowances: ?UserAllowances;
+};
+
+/// Some user actions may not occur more than X number of times per 24 hours.
+/// Equivalently, these actions are limited by "allowances" that are replenished every 24 hours.
+/// These allowances are quasi-private information, since they leak user data, indirectly.
+public type UserAllowances = {
+  abuseFlags : AllowanceBalance ;
+  superLikes : AllowanceBalance ;
 };
 
 /// video information provided by front end to service, upon creation.

--- a/backend/Types.mo
+++ b/backend/Types.mo
@@ -77,11 +77,11 @@ public type ProfileInfoPlus = {
  hasPic: Bool;
  rewards: Nat;
  abuseFlagCount: Nat; // abuseFlags counts other users' flags on this profile, for possible blurring.
- /// abuseFlagFlag is
+ /// viewerHasFlagged is
  /// ?true if we (the User requesting this profile) has flagged this profile for abuse.
  /// ?false if not, and
  /// null if no specific requesting user is defined by context.
- abuseFlagFlag: ?Bool;
+ viewerHasFlagged: ?Bool;
  /// null if not giving a self view of the profile, otherwise, gives UserAllowances for userName.
  allowances: ?UserAllowances;
 };
@@ -120,11 +120,11 @@ public type VideoInfo = {
  name: Text;
  chunkCount: Nat;
  abuseFlagCount: Nat; // abuseFlags counts other users' flags on this profile, for possible blurring.
- /// abuseFlagFlag is
+ /// viewerHasFlagged is
  /// ?true if we (the User requesting this profile) has flagged this profile for abuse.
  /// ?false if not, and
  /// null if no specific requesting user is defined by context.
- abuseFlagFlag: ?Bool; // true if we (the User requesting this profile) has flagged this profile for abuse.
+ viewerHasFlagged: ?Bool; // true if we (the User requesting this profile) has flagged this profile for abuse.
 };
 
 public type VideoResult = (VideoInfo, ?VideoPic);

--- a/service/CanCan.mo
+++ b/service/CanCan.mo
@@ -261,6 +261,10 @@ shared ({caller = initPrincipal}) actor class CanCan () /* : Types.Service */ {
     }
   };
 
+  func getUserAllowances_(user: UserId) : Types.UserAllowances {
+    loop { assert false } // to do
+  };
+
   func getProfilePlus_(caller: ?UserId, userId: UserId): ?ProfileInfoPlus {
     do ? {
       let profile = state.profiles.get(userId)!;
@@ -276,10 +280,9 @@ shared ({caller = initPrincipal}) actor class CanCan () /* : Types.Service */ {
         abuseFlagFlag = do ? { // if caller is non-null,
           state.abuseFlagUsers.isMember(caller!, userId) ; // check if we are there.
         };
-        allowances = if (caller! == userId) {
-          // to do
-          null
-        } else { null };
+        allowances = do ? { if (caller! == userId) {
+          getUserAllowances_(caller!)
+        } else { null! } };
       };
     }
   };

--- a/service/CanCan.mo
+++ b/service/CanCan.mo
@@ -331,7 +331,7 @@ shared ({caller = initPrincipal}) actor class CanCan () /* : Types.Service */ {
         hasPic = false;
         rewards = state.rewards.get(userId)!;
         abuseFlagCount = state.abuseFlagUsers.get1Size(userId) ; // count total for userId.
-        abuseFlagFlag = do ? { // if caller is non-null,
+        viewerHasFlagged = do ? { // if caller is non-null,
           state.abuseFlagUsers.isMember(caller!, userId) ; // check if we are there.
         };
         allowances = do ? { if (caller! == userId) {
@@ -794,7 +794,7 @@ shared ({caller = initPrincipal}) actor class CanCan () /* : Types.Service */ {
         // This implementation makes public all users who flagged every video,
         // but if that information should be kept private, get video info
         // could return just whether the calling user flagged it.
-        abuseFlagFlag = do ? {
+        viewerHasFlagged = do ? {
           state.abuseFlagVideos.isMember(caller!, videoId) ;
         };
         abuseFlagCount = state.abuseFlagVideos.get1Size(videoId);

--- a/service/CanCan.mo
+++ b/service/CanCan.mo
@@ -194,7 +194,13 @@ shared ({caller = initPrincipal}) actor class CanCan () /* : Types.Service */ {
   ///
   /// Gives Video- and ProfileInfos instead of merely Ids in the results.
   ///
-  /// The optional "caller" UserId personalizes the
+  /// The optional "caller" UserId personalizes the resulting record for
+e  /// various cases:
+  /// - When caller is not given, less information is non-null in result.
+  /// - When calling user is viewing their own profile,
+  ///   gives private and quasi-private info to them about their allowances.
+  /// - When calling user is viewing profile of another user,
+  ///   gives private info about super likes / abuse flags toward that use.
   public query(msg) func getProfilePlus(caller: ?UserId, target: UserId): async ?ProfileInfoPlus {
     do ? {
       accessCheck(msg.caller, #view, #user target)!;

--- a/service/tests/accessControl.test.sh
+++ b/service/tests/accessControl.test.sh
@@ -35,7 +35,7 @@ call CanCan.createVideo(record
                           tags = vec { };
                           chunkCount = 1 });
 assert _ == (null : opt null);
-call CanCan.getVideoInfo("alice-cat0-0"); // ok
+call CanCan.getVideoInfo(opt "bob", "alice-cat0-0"); // ok
 assert _ != (null : opt null);
 
 call CanCan.putSuperLike("bob", "alice-cat0-0", true); // ok

--- a/src/components/FlagButton.tsx
+++ b/src/components/FlagButton.tsx
@@ -10,11 +10,11 @@ import reportIcon from "../assets/images/icon-report.png";
 export default function FlagButton({ currentUserId, videoInfo }) {
   // Keep local track of whether video is flagged so we can update the state
   // immediately rather than wait for backend call.
-  const [localFlags, setLocalFlags] = useState(videoInfo.abuseFlagUsers.length);
-  // Keeps track of whether user has already flagged this video.
-  const [isActive, setActive] = useState(
-    videoInfo.abuseFlagUsers.includes(currentUserId)
+  const [localFlags, setLocalFlags] = useState(
+    Number(videoInfo.abuseFlagCount)
   );
+  // Keeps track of whether user has already flagged this video.
+  const [isActive, setActive] = useState(videoInfo.viewerHasFlagged);
   const handleClick = async () => {
     if (!isActive) {
       setActive(true);

--- a/src/components/Video.tsx
+++ b/src/components/Video.tsx
@@ -73,7 +73,7 @@ function VideoBase(props: VideoProps) {
     videoInfo.superLikes.includes(userId)
   );
 
-  const videoIsFlagged = videoInfo.abuseFlagUsers.length >= VIDEO_BLUR_MIN;
+  const videoIsFlagged = videoInfo.abuseFlagCount >= VIDEO_BLUR_MIN;
 
   const videoRef = useRef<HTMLVideoElement>(null);
 

--- a/src/utils/canister.ts
+++ b/src/utils/canister.ts
@@ -92,7 +92,9 @@ export async function isDropDay(): Promise<boolean> {
 export async function getUserFromCanister(
   userId: string
 ): Promise<ProfileInfoPlus | null> {
-  const icUser = unwrap<ProfileInfoPlus>(await CanCan.getProfilePlus(userId));
+  const icUser = unwrap<ProfileInfoPlus>(
+    await CanCan.getProfilePlus([userId], userId)
+  );
   if (icUser) {
     return icUser;
   } else {
@@ -127,8 +129,8 @@ export async function getFeedVideos(userId: string): Promise<VideoInfo[]> {
   }
 }
 
-export async function getVideoInfo(videoId: string) {
-  const videoInfo = unwrap(await CanCan.getVideoInfo(videoId));
+export async function getVideoInfo(userId: string, videoId: string) {
+  const videoInfo = unwrap(await CanCan.getVideoInfo([userId], videoId));
   if (videoInfo !== null) {
     return videoInfo;
   } else {

--- a/src/utils/canister.ts
+++ b/src/utils/canister.ts
@@ -93,7 +93,7 @@ export async function getUserFromCanister(
   userId: string
 ): Promise<ProfileInfoPlus | null> {
   const icUser = unwrap<ProfileInfoPlus>(
-    await CanCan.getProfilePlus([userId], userId)
+    await CanCan.actor.getProfilePlus([userId], userId)
   );
   if (icUser) {
     return icUser;

--- a/src/utils/canister.ts
+++ b/src/utils/canister.ts
@@ -132,7 +132,7 @@ export async function getFeedVideos(userId: string): Promise<VideoInfo[]> {
 }
 
 export async function getVideoInfo(userId: string, videoId: string) {
-  const videoInfo = unwrap(await CanCan.getVideoInfo([userId], videoId));
+  const videoInfo = unwrap(await CanCan.actor.getVideoInfo([userId], videoId));
   if (videoInfo !== null) {
     return videoInfo;
   } else {

--- a/src/utils/canister/typings.d.ts
+++ b/src/utils/canister/typings.d.ts
@@ -180,7 +180,10 @@ export default interface _SERVICE {
   getMessages: (arg_0: UserId_3) => Promise<[] | [Message]>;
   getProfileInfo: (arg_0: UserId_3) => Promise<[] | [ProfileInfo]>;
   getProfilePic: (arg_0: UserId_3) => Promise<[] | [ProfilePic]>;
-  getProfilePlus: (arg_0: UserId_3) => Promise<[] | [ProfileInfoPlus]>;
+  getProfilePlus: (
+    arg_0: [] | [UserId_2],
+    arg_1: UserId_3
+  ) => Promise<[] | [ProfileInfoPlus]>;
   getProfileVideos: (
     arg_0: UserId_3,
     arg_1: [] | [number]
@@ -200,7 +203,10 @@ export default interface _SERVICE {
     arg_0: VideoId_3,
     arg_1: number
   ) => Promise<[] | [Array<number>]>;
-  getVideoInfo: (arg_0: VideoId_3) => Promise<[] | [VideoInfo]>;
+  getVideoInfo: (
+    arg_0: [] | [UserId_2],
+    arg_1: VideoId_3
+  ) => Promise<[] | [VideoInfo]>;
   getVideoPic: (arg_0: VideoId_3) => Promise<[] | [VideoPic]>;
   getVideos: () => Promise<[] | [VideoInfo]>;
   isDropDay: () => Promise<[] | [boolean]>;

--- a/src/utils/video.ts
+++ b/src/utils/video.ts
@@ -74,7 +74,7 @@ async function uploadVideo(userId: string, file: File, caption: string) {
 
   await Promise.all(putChunkPromises);
 
-  return await checkVidFromIC(videoId);
+  return await checkVidFromIC(videoId, userId);
 }
 
 // This isn't Internet Computer specific, just a helper to generate an image
@@ -133,9 +133,9 @@ async function uploadVideoPic(videoId: string, file: number[]) {
 }
 
 // Gets videoInfo from the IC after we've uploaded
-async function checkVidFromIC(videoId: string) {
+async function checkVidFromIC(videoId: string, userId: string) {
   console.log("Checking canister for uploaded video...");
-  const resultFromCanCan = await getVideoInfo(videoId);
+  const resultFromCanCan = await getVideoInfo(userId, videoId);
   if (resultFromCanCan === null) {
     throw Error("Invalid video received from CanCan Canister");
   }


### PR DESCRIPTION
On a large active deployment, it shouldn't be possible to see who has flagged what profile or video, just determine the total count, and determine if we (the user in question) are among them.  That's what this new design provides.

This is a PR that attends to some private information leakage in the current API design.  We discussed this issue already, and the solution is here.  

It consists of:
 - explicitly providing the username on requests that could have that user's flags (just additionally video info, for now).
 - removing the list of users that flag, and replacing with a flag that says if we are one of the flaggers.  I call the new field `abuseFlagFlag`, for lack of a better name.
 - This boolean is optional, sense sometimes it makes no sense to see a personalized view of a video.
 - When it is present (not `null`) the BE is now doing more access control checks when we view things, to ensure we can see private flags. 