### PR TITLE
Private abuse flags frontend

### DIFF
--- a/src/components/FlagButton.tsx
+++ b/src/components/FlagButton.tsx
@@ -10,11 +10,11 @@ import reportIcon from "../assets/images/icon-report.png";
 export default function FlagButton({ currentUserId, videoInfo }) {
   // Keep local track of whether video is flagged so we can update the state
   // immediately rather than wait for backend call.
-  const [localFlags, setLocalFlags] = useState(videoInfo.abuseFlagUsers.length);
-  // Keeps track of whether user has already flagged this video.
-  const [isActive, setActive] = useState(
-    videoInfo.abuseFlagUsers.includes(currentUserId)
+  const [localFlags, setLocalFlags] = useState(
+    Number(videoInfo.abuseFlagCount)
   );
+  // Keeps track of whether user has already flagged this video.
+  const [isActive, setActive] = useState(videoInfo.viewerHasFlagged);
   const handleClick = async () => {
     if (!isActive) {
       setActive(true);

--- a/src/components/Video.tsx
+++ b/src/components/Video.tsx
@@ -73,7 +73,7 @@ function VideoBase(props: VideoProps) {
     videoInfo.superLikes.includes(userId)
   );
 
-  const videoIsFlagged = videoInfo.abuseFlagUsers.length >= VIDEO_BLUR_MIN;
+  const videoIsFlagged = videoInfo.abuseFlagCount >= VIDEO_BLUR_MIN;
 
   const videoRef = useRef<HTMLVideoElement>(null);
 

--- a/src/utils/canister.ts
+++ b/src/utils/canister.ts
@@ -92,7 +92,9 @@ export async function isDropDay(): Promise<boolean> {
 export async function getUserFromCanister(
   userId: string
 ): Promise<ProfileInfoPlus | null> {
-  const icUser = unwrap<ProfileInfoPlus>(await CanCan.getProfilePlus(userId));
+  const icUser = unwrap<ProfileInfoPlus>(
+    await CanCan.getProfilePlus([userId], userId)
+  );
   if (icUser) {
     return icUser;
   } else {
@@ -127,8 +129,8 @@ export async function getFeedVideos(userId: string): Promise<VideoInfo[]> {
   }
 }
 
-export async function getVideoInfo(videoId: string) {
-  const videoInfo = unwrap(await CanCan.getVideoInfo(videoId));
+export async function getVideoInfo(userId: string, videoId: string) {
+  const videoInfo = unwrap(await CanCan.getVideoInfo([userId], videoId));
   if (videoInfo !== null) {
     return videoInfo;
   } else {

--- a/src/utils/canister/typings.d.ts
+++ b/src/utils/canister/typings.d.ts
@@ -180,7 +180,10 @@ export default interface _SERVICE {
   getMessages: (arg_0: UserId_3) => Promise<[] | [Message]>;
   getProfileInfo: (arg_0: UserId_3) => Promise<[] | [ProfileInfo]>;
   getProfilePic: (arg_0: UserId_3) => Promise<[] | [ProfilePic]>;
-  getProfilePlus: (arg_0: UserId_3) => Promise<[] | [ProfileInfoPlus]>;
+  getProfilePlus: (
+    arg_0: [] | [UserId_2],
+    arg_1: UserId_3
+  ) => Promise<[] | [ProfileInfoPlus]>;
   getProfileVideos: (
     arg_0: UserId_3,
     arg_1: [] | [number]
@@ -200,7 +203,10 @@ export default interface _SERVICE {
     arg_0: VideoId_3,
     arg_1: number
   ) => Promise<[] | [Array<number>]>;
-  getVideoInfo: (arg_0: VideoId_3) => Promise<[] | [VideoInfo]>;
+  getVideoInfo: (
+    arg_0: [] | [UserId_2],
+    arg_1: VideoId_3
+  ) => Promise<[] | [VideoInfo]>;
   getVideoPic: (arg_0: VideoId_3) => Promise<[] | [VideoPic]>;
   getVideos: () => Promise<[] | [VideoInfo]>;
   isDropDay: () => Promise<[] | [boolean]>;

--- a/src/utils/video.ts
+++ b/src/utils/video.ts
@@ -74,7 +74,7 @@ async function uploadVideo(userId: string, file: File, caption: string) {
 
   await Promise.all(putChunkPromises);
 
-  return await checkVidFromIC(videoId);
+  return await checkVidFromIC(videoId, userId);
 }
 
 // This isn't Internet Computer specific, just a helper to generate an image
@@ -133,9 +133,9 @@ async function uploadVideoPic(videoId: string, file: number[]) {
 }
 
 // Gets videoInfo from the IC after we've uploaded
-async function checkVidFromIC(videoId: string) {
+async function checkVidFromIC(videoId: string, userId: string) {
   console.log("Checking canister for uploaded video...");
-  const resultFromCanCan = await getVideoInfo(videoId);
+  const resultFromCanCan = await getVideoInfo(userId, videoId);
   if (resultFromCanCan === null) {
     throw Error("Invalid video received from CanCan Canister");
   }


### PR DESCRIPTION
Sets more prescriptive rules about browser support to ensure browserlist doesn't include browsers which don't support `**`, as this project uses libraries which require it.