### PR TITLE
set dfx.json:dfx to 0.7.0

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -46,5 +46,5 @@
       "type": "ephemeral"
     }
   },
-  "dfx": "0.7.0-beta.6"
+  "dfx": "0.7.0"
 }


### PR DESCRIPTION
Motivation:
* Test if ci passes with dfx 0.7.0 - I tried locally, and the home feed didn't show up. Just saw a black screen. No other errors.