### PR TITLE
Fix / not redirecting to /sign-in

### DIFF
--- a/src/utils/auth.tsx
+++ b/src/utils/auth.tsx
@@ -151,7 +151,7 @@ export function useProvideAuth(authClient): AuthContext {
 
   return {
     isAuthenticated,
-    isAuthReady: isAuthClientReady && actorController.isReady,
+    isAuthReady: isAuthClientReady,
     hasCanCanAccount: user !== undefined,
     logIn,
     logOut,

--- a/src/utils/canister.ts
+++ b/src/utils/canister.ts
@@ -40,7 +40,7 @@ export function getUserFromStorage(
 
 export async function getUserNameByPrincipal(principal: Principal) {
   const icUserName = unwrap<string>(
-    await CanCan.actor.getUserNameByPrincipal(principal)
+    await (await CanCan.actor).getUserNameByPrincipal(principal)
   )!;
   return icUserName;
 }
@@ -53,7 +53,7 @@ export async function createUser(
     throw Error("trying to create user without principal");
   }
   const profile = unwrap<ProfileInfoPlus>(
-    await CanCan.actor.createProfile(userId, [])
+    await (await CanCan.actor).createProfile(userId, [])
   );
   if (profile) {
     return profile;
@@ -86,14 +86,14 @@ export async function findOrCreateUser(
 }
 
 export async function isDropDay(): Promise<boolean> {
-  return Boolean(unwrap<boolean>(await CanCan.actor.isDropDay()));
+  return Boolean(unwrap<boolean>(await (await CanCan.actor).isDropDay()));
 }
 
 export async function getUserFromCanister(
   userId: string
 ): Promise<ProfileInfoPlus | null> {
   const icUser = unwrap<ProfileInfoPlus>(
-    await CanCan.actor.getProfilePlus([userId], userId)
+    await (await CanCan.actor).getProfilePlus([userId], userId)
   );
   if (icUser) {
     return icUser;
@@ -109,7 +109,7 @@ export async function getSearchVideos(
 ): Promise<VideoInfo[]> {
   // @ts-ignore
   const videos = unwrap<VideoResults>(
-    await CanCan.actor.getSearchVideos(userId, terms, limit)
+    await (await CanCan.actor).getSearchVideos(userId, terms, limit)
   );
   if (videos !== null) {
     const unwrappedVideos = videos.map((v) => v[0]);
@@ -121,7 +121,7 @@ export async function getSearchVideos(
 
 export async function getFeedVideos(userId: string): Promise<VideoInfo[]> {
   const videos = unwrap<VideoResults>(
-    await CanCan.actor.getFeedVideos(userId, [])
+    await (await CanCan.actor).getFeedVideos(userId, [])
   );
   if (videos !== null) {
     const unwrappedVideos = videos.map((v) => v[0]);
@@ -132,7 +132,9 @@ export async function getFeedVideos(userId: string): Promise<VideoInfo[]> {
 }
 
 export async function getVideoInfo(userId: string, videoId: string) {
-  const videoInfo = unwrap(await CanCan.actor.getVideoInfo([userId], videoId));
+  const videoInfo = unwrap(
+    await (await CanCan.actor).getVideoInfo([userId], videoId)
+  );
   if (videoInfo !== null) {
     return videoInfo;
   } else {
@@ -140,12 +142,14 @@ export async function getVideoInfo(userId: string, videoId: string) {
   }
 }
 export async function getProfilePic(userId: string) {
-  const profilePic = unwrap(await CanCan.actor.getProfilePic(userId));
+  const profilePic = unwrap(await (await CanCan.actor).getProfilePic(userId));
   return profilePic;
 }
 
 export async function createVideo(videoInit: VideoInit): Promise<string> {
-  const videoId = unwrap<string>(await CanCan.actor.createVideo(videoInit));
+  const videoId = unwrap<string>(
+    await (await CanCan.actor).createVideo(videoInit)
+  );
   if (videoId) {
     return videoId;
   } else {
@@ -159,7 +163,11 @@ export async function follow(
   willFollow: boolean
 ) {
   try {
-    await CanCan.actor.putProfileFollow(userToFollow, follower, willFollow);
+    await (await CanCan.actor).putProfileFollow(
+      userToFollow,
+      follower,
+      willFollow
+    );
   } catch (error) {
     console.error(error);
   }
@@ -167,7 +175,7 @@ export async function follow(
 
 export async function like(user: string, videoId: string, willLike: boolean) {
   try {
-    await CanCan.actor.putProfileVideoLike(user, videoId, willLike);
+    await (await CanCan.actor).putProfileVideoLike(user, videoId, willLike);
   } catch (error) {
     console.error(error);
   }
@@ -179,7 +187,7 @@ export async function superLike(
   willSuperLike: boolean
 ) {
   try {
-    await CanCan.actor.putSuperLike(user, videoId, willSuperLike);
+    await (await CanCan.actor).putSuperLike(user, videoId, willSuperLike);
   } catch (error) {
     console.error(error);
   }
@@ -191,7 +199,7 @@ export async function getVideoChunks(videoInfo: VideoInfo): Promise<string> {
   const chunkBuffers: Buffer[] = [];
   const chunksAsPromises: Array<Promise<Optional<number[]>>> = [];
   for (let i = 1; i <= Number(chunkCount.toString()); i++) {
-    chunksAsPromises.push(CanCan.actor.getVideoChunk(videoId, i));
+    chunksAsPromises.push((await CanCan.actor).getVideoChunk(videoId, i));
   }
   const nestedBytes: number[][] = (await Promise.all(chunksAsPromises))
     .map(unwrap)
@@ -212,15 +220,15 @@ export async function putVideoChunk(
   chunkNum: number,
   chunkData: number[]
 ) {
-  return CanCan.actor.putVideoChunk(videoId, chunkNum, chunkData);
+  return (await CanCan.actor).putVideoChunk(videoId, chunkNum, chunkData);
 }
 
 export async function putVideoPic(videoId: string, file: number[]) {
-  return CanCan.actor.putVideoPic(videoId, [file]);
+  return (await CanCan.actor).putVideoPic(videoId, [file]);
 }
 
 export async function getVideoPic(videoId: string): Promise<number[]> {
-  const icResponse = await CanCan.actor.getVideoPic(videoId);
+  const icResponse = await (await CanCan.actor).getVideoPic(videoId);
   const pic = unwrap<number[]>(icResponse);
   if (pic !== null) {
     return pic;
@@ -241,11 +249,11 @@ export function getLocationCanisterPrincipal(location: Location): Principal {
 }
 
 export async function checkUsername(username: string): Promise<boolean> {
-  return await CanCan.actor.checkUsernameAvailable(username);
+  return await (await CanCan.actor).checkUsernameAvailable(username);
 }
 
 export async function getMessages(username: string): Promise<Message[]> {
-  const messages = await CanCan.actor.getMessages(username);
+  const messages = await (await CanCan.actor).getMessages(username);
   return messages;
 }
 
@@ -254,7 +262,11 @@ export async function putRewardTransfer(
   recipient: string,
   amount: BigInt
 ) {
-  return await CanCan.actor.putRewardTransfer(sender, recipient, amount);
+  return await (await CanCan.actor).putRewardTransfer(
+    sender,
+    recipient,
+    amount
+  );
 }
 
 export async function putAbuseFlagVideo(
@@ -262,5 +274,9 @@ export async function putAbuseFlagVideo(
   target: string,
   shouldFlag: boolean
 ) {
-  return await CanCan.actor.putAbuseFlagVideo(reporter, target, shouldFlag);
+  return await (await CanCan.actor).putAbuseFlagVideo(
+    reporter,
+    target,
+    shouldFlag
+  );
 }

--- a/src/utils/canister/actor.ts
+++ b/src/utils/canister/actor.ts
@@ -32,19 +32,18 @@ function createActor(identity?: Identity) {
  * Identity, to ensure their Principal is passed to the backend.
  */
 class ActorController {
-  _actor: _SERVICE;
+  _actor: Promise<_SERVICE>;
   _isAuthenticated: boolean = false;
-  isReady: boolean = false;
 
   constructor() {
     this._actor = this.initBaseActor();
   }
 
-  initBaseActor() {
-    const { agent, actor } = createActor();
+  async initBaseActor(identity?: Identity) {
+    const { agent, actor } = createActor(identity);
     // The root key only has to be fetched for local development environments
     if (isLocalEnv) {
-      agent.fetchRootKey().then(() => (this.isReady = true));
+      await agent.fetchRootKey();
     }
     return actor;
   }
@@ -61,13 +60,8 @@ class ActorController {
    * to create a new actor with it, so they pass their Principal to the backend.
    */
   async authenticateActor(identity: Identity) {
-    const { agent, actor } = createActor(identity);
-    if (isLocalEnv) {
-      await agent.fetchRootKey();
-    }
-    this._actor = actor;
+    this._actor = this.initBaseActor(identity);
     this._isAuthenticated = true;
-    this.isReady = true;
   }
 
   /*
@@ -75,6 +69,7 @@ class ActorController {
    */
   unauthenticateActor() {
     this._actor = this.initBaseActor();
+    this._isAuthenticated = false;
   }
 }
 


### PR DESCRIPTION
useAuth() hook wasnt return isAuthReady when end-user is logged out.
This was because of how ActorController changed isReady without a way of awaiting that change.
Now ActorController.actor is a Promise<Actor> (and the promise includes fetchRootKey() if appropriate).

Motivation:
* https://github.com/dfinity/cancan/issues/26