### PR TITLE
chore(license): removes modified boilerplate from license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -181,28 +181,3 @@ deem waived or otherwise exclude such Section(s) of the License, but only in
 their entirety and only with respect to the Combined Software.
 
 END OF LLVM EXCEPTION
-
-APPENDIX: How to apply the Apache License to your work.
-
-To apply the Apache License to your work, attach the following boilerplate
-notice, with the fields enclosed by brackets "[]" replaced with your own
-identifying information. (Don't include the brackets!)  The text should be
-enclosed in the appropriate comment syntax for the file format. We also
-recommend that a file or class name and description of purpose be included on
-the same "printed page" as the copyright notice for easier identification
-within third-party archives.
-
-Copyright 2021 DFINITY Foundation
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-this file except in compliance with the License. You may obtain a copy of the
-License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software distributed
-under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-CONDITIONS OF ANY KIND, either express or implied. See the License for the
-specific language governing permissions and limitations under the License.
-
-END OF APPENDIX


### PR DESCRIPTION
This PR removes the modified appendix from the LICENSE file to ensure full compliance with the Apache 2.0 license, which should remain in its original, unmodified form. This change aligns our repositories with standard practices for license documentation.